### PR TITLE
fix: Single and double quotes are not working as expected

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,33 +4,54 @@ module.exports = crossArgv
 
 function crossArgv (pargv, force) {
   if (!pargv) pargv = process.argv
-  if (!IS_WINDOWS && !force) return pargv
+  const str = pargv.join(` `)
+  if (((!IS_WINDOWS || (str.match(/'/g) || []).length < 2) && !force)) return pargv
 
-  const argv = []
-  var tmp = []
+  const newStr = str.replace(/'(.+?)'/g, `"$1"`)
+  return splitCommandLine(newStr)
+}
 
-  for (var i = 0; i < pargv.length; i++) {
-    const v = pargv[i]
+/**
+ * @form https://stackoverflow.com/a/56930457/12391660
+ * @param {*} commandLine
+ * @returns
+ */
+function splitCommandLine (commandLine) {
+  //  Find a unique marker for pairs of double-quote characters.
+  //  Start with '<DDQ>' and repeatedly append '@' if necessary to make it unique.
+  var doubleDoubleQuote = '<DDQ>'
+  while (commandLine.indexOf(doubleDoubleQuote) > -1) doubleDoubleQuote += '@'
 
-    if (v[v.length - 1] === "'" && tmp.length) {
-      tmp.push(v)
-      argv.push(tmp.join(' ').slice(1, -1))
-      tmp = []
-      continue
-    }
+  //  Replace all pairs of double-quotes with above marker.
+  var noDoubleDoubleQuotes = commandLine.replace(/""/g, doubleDoubleQuote)
 
-    if (tmp.length) {
-      tmp.push(v)
-      continue
-    }
+  //  As above, find a unique marker for spaces.
+  var spaceMarker = '<SP>'
+  while (commandLine.indexOf(spaceMarker) > -1) spaceMarker += '@'
 
-    if (v[0] === "'") {
-      tmp.push(v)
-      continue
-    }
+  //  Protect double-quoted strings.
+  //   o  Find strings of non-double-quotes, wrapped in double-quotes.
+  //   o  The final double-quote is optional to allow for an unterminated string.
+  //   o  Replace each double-quoted-string with what's inside the qouble-quotes,
+  //      after each space character has been replaced with the space-marker above;
+  //      and each double-double-quote marker has been replaced with a double-
+  //      quote character.
+  //   o  The outer double-quotes will not be present.
+  var noSpacesInQuotes = noDoubleDoubleQuotes.replace(/"([^"]*)"?/g, (fullMatch, capture) => {
+    return capture.replace(/ /g, spaceMarker)
+      .replace(RegExp(doubleDoubleQuote, 'g'), '"')
+  })
 
-    argv.push(v)
-  }
+  //  Now that it is safe to do so, split the command-line at one-or-more spaces.
+  var mangledParamArray = noSpacesInQuotes.split(/ +/)
 
-  return argv
+  //  Create a new array by restoring spaces from any space-markers. Also, any
+  //  remaining double-double-quote markers must have been from OUTSIDE a double-
+  //  quoted string and so are removed.
+  var paramArray = mangledParamArray.map((mangledParam) => {
+    return mangledParam.replace(RegExp(spaceMarker, 'g'), ' ')
+      .replace(RegExp(doubleDoubleQuote, 'g'), '')
+  })
+
+  return paramArray
 }

--- a/test.js
+++ b/test.js
@@ -2,6 +2,7 @@ const tape = require('tape')
 const xargv = require('./')
 
 tape('basic', function (t) {
+  t.same(xargv(['node', 'app.js', "a1='a", "b'", 'a2', "'c", "d'", "'e", 'e'], true), ['node', 'app.js', 'a1=a b', 'a2', 'c d', "'e", 'e'])
   t.same(xargv(['node', 'app.js', "'foo", 'bar', "baz'"], true), ['node', 'app.js', 'foo bar baz'])
   t.same(xargv(['node', "app's"], true), ['node', "app's"])
   t.same(xargv(['a', 'b', 'c'], true), ['a', 'b', 'c'])


### PR DESCRIPTION
- [#1](https://github.com/mafintosh/cross-argv/issues/1)

```
> standard && tape test.js

TAP version 13
# basic
ok 1 should be equivalent
ok 2 should be equivalent
ok 3 should be equivalent
ok 4 should be equivalent

1..4
# tests 4
# pass  4

# ok
```